### PR TITLE
tooltip lower case bug fix

### DIFF
--- a/encon_extension/scripts/word_finder.js
+++ b/encon_extension/scripts/word_finder.js
@@ -91,7 +91,7 @@ function findWords(words) {
   let tooltipMap = new Map();
 
   marks.forEach((mark) => { // For each mark, create a tooltip
-    let word = mark.textContent.trim();
+    let word = mark.textContent.trim().toLowerCase();
 
     if (!tooltipMap.has(word)) { // If the tooltip doesn't exist, create it
       let tooltip = document.createElement("div");


### PR DESCRIPTION
Bug: Extension deemed "Test" and "TEST" as not having a definition but "test" does have a definition.

Fixed: Extension now recognizes that "Test" and "TEST" do have a definition